### PR TITLE
feat: revoke access on password change

### DIFF
--- a/LockedPages.php
+++ b/LockedPages.php
@@ -28,8 +28,12 @@ final class LockedPages
         $access = App::instance()->session(['long' => true])->data()->get(LockedPages::SESSION_KEY, []);
         foreach($access as $index => $entry) {
           $urlpass = explode("|", $entry, 2);
-          if ( $urlpass[0] == $protectedPage->uri() && password_verify($protectedPage->lockedPagesPassword()->value(), $urlpass[1]) ) {
-            return false;
+          if (
+              count($urlpass) === 2 &&
+              $urlpass[0] == $protectedPage->uri() &&
+              password_verify($protectedPage->lockedPagesPassword()->value(), $urlpass[1])
+          ) {
+              return false;
           }
         }
 

--- a/LockedPages.php
+++ b/LockedPages.php
@@ -9,6 +9,9 @@ final class LockedPages
 {
     public const SESSION_KEY = 'johannschopplich.locked-pages.access';
 
+    /**
+     * Check if a page or one of its parents is locked and if the user has access
+     */
     public static function isLocked(Page|null $page): bool
     {
         if (!$page) {
@@ -23,18 +26,25 @@ final class LockedPages
         if (!$protectedPage) {
             return false;
         }
-        
-        // check if Session has URL/password hash
-        $access = App::instance()->session(['long' => true])->data()->get(LockedPages::SESSION_KEY, []);
-        foreach($access as $index => $entry) {
-          $urlpass = explode("|", $entry, 2);
-          if (
-              count($urlpass) === 2 &&
-              $urlpass[0] == $protectedPage->uri() &&
-              password_verify($protectedPage->lockedPagesPassword()->value(), $urlpass[1])
-          ) {
-              return false;
-          }
+
+        // Check if user has valid access to this protected page
+        $access = App::instance()->session(['long' => true])->data()->get(static::SESSION_KEY, []);
+        $currentPassword = $protectedPage->lockedPagesPassword()->value();
+
+        foreach ($access as $entry) {
+            // Handle both old format (string) and new format (array) for backward compatibility
+            if (is_string($entry)) {
+                continue;
+            }
+
+            if (
+                is_array($entry) &&
+                isset($entry['uri'], $entry['password_hash']) &&
+                $entry['uri'] === $protectedPage->uri() &&
+                password_verify($currentPassword, $entry['password_hash'])
+            ) {
+                return false;
+            }
         }
 
         return true;
@@ -51,5 +61,42 @@ final class LockedPages
         }
 
         return null;
+    }
+
+    /**
+     * Clean up session data and remove invalid entries
+     */
+    public static function cleanupSessionData(): void
+    {
+        $session = App::instance()->session(['long' => true]);
+        $access = $session->data()->get(static::SESSION_KEY, []);
+
+        // Filter out old string format entries and invalid data
+        $cleanAccess = array_filter($access, function($entry) {
+            return is_array($entry) &&
+                   isset($entry['uri'], $entry['password_hash']) &&
+                   is_string($entry['uri']) &&
+                   is_string($entry['password_hash']);
+        });
+
+        // Re-index array to avoid gaps
+        $cleanAccess = array_values($cleanAccess);
+
+        $session->data()->set(static::SESSION_KEY, $cleanAccess);
+    }
+
+    /**
+     * Revoke access for a specific page URI
+     */
+    public static function revokeAccess(string $uri): void
+    {
+        $session = App::instance()->session(['long' => true]);
+        $access = $session->data()->get(static::SESSION_KEY, []);
+
+        $access = array_filter($access, function($entry) use ($uri) {
+            return !(is_array($entry) && isset($entry['uri']) && $entry['uri'] === $uri);
+        });
+
+        $session->data()->set(static::SESSION_KEY, array_values($access));
     }
 }

--- a/LockedPages.php
+++ b/LockedPages.php
@@ -23,10 +23,14 @@ final class LockedPages
         if (!$protectedPage) {
             return false;
         }
-
+        
+        // check if Session has URL/password hash
         $access = App::instance()->session(['long' => true])->data()->get(LockedPages::SESSION_KEY, []);
-        if (in_array($protectedPage->uri(), $access)) {
+        foreach($access as $index => $entry) {
+          $urlpass = explode("|", $entry, 2);
+          if ( $urlpass[0] == $protectedPage->uri() && password_verify($protectedPage->lockedPagesPassword()->value(), $urlpass[1]) ) {
             return false;
+          }
         }
 
         return true;

--- a/controllers/locked-pages-login.php
+++ b/controllers/locked-pages-login.php
@@ -6,20 +6,19 @@ return function (\Kirby\Cms\App $kirby) {
     $uri = get('redirect');
     $targetPage = page($uri);
 
-    // Make sure page with given id exists
+    // Ensure target page exists
     if ($targetPage === null) {
         return [
             'error' => false
         ];
     }
 
-    // If page or one of its parent isn't locked or the user has entered
-    // the password this session already, visit the page immediately
+    // If page is not locked or user has access already, just go to the page
     if (!LockedPages::isLocked($targetPage)) {
         go($uri);
     }
 
-    // Make sure this is a post request
+    // Ensure it's a POST request
     if (!$kirby->request()->is('POST')) {
         return [
             'error' => false
@@ -28,7 +27,7 @@ return function (\Kirby\Cms\App $kirby) {
 
     $csrfToken = get('csrf');
 
-    // Verify token of form
+    // Verify the token of the form
     if (csrf($csrfToken) === false) {
         return [
             'error' => option('johannschopplich.locked-pages.error.csrf', 'The CSRF token is invalid')
@@ -45,13 +44,29 @@ return function (\Kirby\Cms\App $kirby) {
     }
 
     // Get list of pages where logged in already
-    $access = $kirby->session()->data()->pull(LockedPages::SESSION_KEY, []);
+    $access = $kirby->session()->data()->get(LockedPages::SESSION_KEY, []);
 
-    // Save page and hashed password
-    $passhash = password_hash(get('password'), PASSWORD_DEFAULT);
-    $access[] = $protectedPage->uri() . '|' . $passhash;
+    // Clean up old format entries and entries for the same URI
+    $access = array_filter($access, function($entry) use ($protectedPage) {
+        // Remove old string format entries
+        if (is_string($entry)) {
+            return false;
+        }
+        // Remove existing entries for the same URI (to update with new password hash)
+        if (is_array($entry) && isset($entry['uri']) && $entry['uri'] === $protectedPage->uri()) {
+            return false;
+        }
+        return true;
+    });
 
-    // Save access list 
+    // Add new access entry with structured data
+    $access[] = [
+        'uri' => $protectedPage->uri(),
+        'password_hash' => password_hash(get('password'), PASSWORD_DEFAULT),
+        'granted_at' => time()
+    ];
+
+    // Save access list
     $kirby->session()->data()->set(LockedPages::SESSION_KEY, $access);
 
     // Finally, visit the page

--- a/controllers/locked-pages-login.php
+++ b/controllers/locked-pages-login.php
@@ -47,10 +47,11 @@ return function (\Kirby\Cms\App $kirby) {
     // Get list of pages where logged in already
     $access = $kirby->session()->data()->pull(LockedPages::SESSION_KEY, []);
 
-    // Redirect future requests to this page id immediately for this session
-    $access[] = $protectedPage->uri();
+    // Save page and hashed password
+    $passhash = password_hash(get('password'), PASSWORD_DEFAULT);
+    $access[] = $protectedPage->uri() . '|' . $passhash;
 
-    // Save access list
+    // Save access list 
     $kirby->session()->data()->set(LockedPages::SESSION_KEY, $access);
 
     // Finally, visit the page

--- a/extensions/hooks.php
+++ b/extensions/hooks.php
@@ -28,7 +28,6 @@ return [
 
     'locked-pages.logout' => function () {
         $kirby = App::instance();
-        $key = LockedPages::SESSION_KEY;
-        $kirby->session()->data()->remove($key);
+        $kirby->session()->data()->remove(LockedPages::SESSION_KEY);
     }
 ];

--- a/index.php
+++ b/index.php
@@ -1,10 +1,12 @@
 <?php
 
+use Kirby\Cms\App;
+
 load([
     'JohannSchopplich\\LockedPages' => 'LockedPages.php'
 ], __DIR__);
 
-\Kirby\Cms\App::plugin('johannschopplich/locked-pages', [
+App::plugin('johannschopplich/locked-pages', [
     'hooks' => require __DIR__ . '/extensions/hooks.php',
     'routes' => require __DIR__ . '/extensions/routes.php',
     'blueprints' => [


### PR DESCRIPTION
Store password hash in session to make it possible to revoke access after password-change, see https://github.com/johannschopplich/kirby-locked-pages/issues/16, however page passwords are still stored in plaintext.